### PR TITLE
Removing console log for complex objects.

### DIFF
--- a/lib/cases.ts
+++ b/lib/cases.ts
@@ -13,10 +13,7 @@ export function cases(parameters: any[]): BddDsl {
             parameters.forEach((parameter, idx) => {
                 const aCase = new Case(idx, parameter, description);
                 it(aCase.buildDescription(),
-                    () => {
-                        aCase.logCase();
-                        return code(parameter);
-                    },
+                    () => code(parameter),
                     timeout);
             });
         },
@@ -37,18 +34,13 @@ export class Case {
         return `${this.description} (${this.parameter}) [${this.index}]`;
     }
 
-    logCase() {
-        if (this.hasComplexParameter()) {
-            console.log(`Case #${this.index} -- Parameters:`, this.parameter);
-        }
-    }
-
     private hasComplexParameter() {
         return this.paramIsANonEmptyObject() && !this.paramIsArray();
     }
 
     private paramIsANonEmptyObject() {
         return typeof this.parameter === 'object'
+            && this.parameter !== null
             && Object.keys(this.parameter).length > 0;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-parameterized",
-  "version": "0.5.0",
+  "version": "1.0.0",
   "description": "Parameterized unit tests for Jasmine",
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",

--- a/spec/basic_example.spec.ts
+++ b/spec/basic_example.spec.ts
@@ -14,7 +14,10 @@ describe('Customer', () => {
     cases([
         3,
         15,
-        18
+        18,
+        null,
+        undefined,
+        {}
     ])
     .it('should not be a child in other cases', (age) => {
         const customer = new Customer(age);

--- a/spec/cases.spec.ts
+++ b/spec/cases.spec.ts
@@ -56,6 +56,24 @@ describe('Case', () => {
             expect(result).toContain(' (4,IV)');
         });
 
+        it('should include param when it is null', () => {
+            const parameter = null;
+            const aCase = new Case(0, parameter, aDescription);
+
+            const result = aCase.buildDescription();
+
+            expect(result).toContain(' (null)');
+        });
+
+        it('should include param when it is undefined', () => {
+            const parameter = undefined;
+            const aCase = new Case(0, parameter, aDescription);
+
+            const result = aCase.buildDescription();
+
+            expect(result).toContain(' (undefined)');
+        });
+
         it('should not include param when it is an object', () => {
             const parameter = {x: 0, y: 1};
             const aCase = new Case(0, parameter, aDescription);
@@ -63,37 +81,6 @@ describe('Case', () => {
             const result = aCase.buildDescription();
 
             expect(result).toEqual('a spec description [0]');
-        });
-
-    });
-
-    describe('logCase()', () => {
-
-        it('should log case details when param is a complex object', () => {
-            let parameter = {x: 0, y: 1};
-
-            let aCase = new Case(3, parameter, 'description');
-            aCase.logCase();
-
-            expect(console.log).toHaveBeenCalledWith('Case #3 -- Parameters:', parameter)
-        });
-
-        it('should not log case details when param is an empty object', () => {
-            let parameter = {};
-
-            let aCase = new Case(3, parameter, 'description');
-            aCase.logCase();
-
-            expect(console.log).not.toHaveBeenCalled()
-        });
-
-        it('should not log case details when param is a primitive or an array', () => {
-            let parameter = 'a parameter';
-
-            let aCase = new Case(3, parameter, 'description');
-            aCase.logCase();
-
-            expect(console.log).not.toHaveBeenCalled()
         });
 
     });


### PR DESCRIPTION
Removing console log for complex objects.
Show null value in test name for null parameter.

Examples:
Customer
    ✓ should be a child when aged 4 to 14 years (4) [0]
    ✓ should be a child when aged 4 to 14 years (14) [1]
    ✓ should not be a child in other cases (3) [0]
    ✓ should not be a child in other cases (15) [1]
    ✓ should not be a child in other cases (18) [2]
    ✓ should not be a child in other cases (null) [3]
    ✓ should not be a child in other cases (undefined) [4]
    ✓ should not be a child in other cases ([object Object]) [5]